### PR TITLE
`Eq` instances for `Static` and `Closure`.

### DIFF
--- a/src/Control/Distributed/Static.hs
+++ b/src/Control/Distributed/Static.hs
@@ -255,11 +255,11 @@ import Data.Rank1Typeable
 data StaticLabel =
     StaticLabel String
   | StaticApply StaticLabel StaticLabel
-  deriving (Eq, Typeable, Show)
+  deriving (Eq, Ord, Typeable, Show)
 
 -- | A static value. Static is opaque; see 'staticLabel' and 'staticApply'.
 newtype Static a = Static StaticLabel
-  deriving (Eq, Typeable, Show)
+  deriving (Eq, Ord, Typeable, Show)
 
 instance Typeable a => Binary (Static a) where
   put (Static label) = putStaticLabel label >> put (typeOf (undefined :: a))
@@ -342,7 +342,7 @@ unstatic rtable (Static static) = do
 
 -- | A closure is a static value and an encoded environment
 data Closure a = Closure (Static (ByteString -> a)) ByteString
-  deriving (Eq, Typeable, Show)
+  deriving (Eq, Ord, Typeable, Show)
 
 instance Typeable a => Binary (Closure a) where
   put (Closure static env) = put static >> put env


### PR DESCRIPTION
`Static` and `Closure` are morally _pointers_ to static values and
closures, respectively. As such, even in cases where it's non-sensical
to have `Eq` instances for the values they point to, it still make sense
to compare pointers (or "references") to them. Just as e.g. `Ptr` and
`StablePtr` have `Eq` instances, arguably so should `Static` and
`Closure`.

cc @yoeight.
