### PR TITLE
Support static pointers

### DIFF
--- a/distributed-static.cabal
+++ b/distributed-static.cabal
@@ -1,6 +1,6 @@
 Name:                distributed-static
 Version:             0.3.3.0
-Synopsis:            Compositional, type-safe, polymorphic static values and closures 
+Synopsis:            Compositional, type-safe, polymorphic static values and closures
 Description:         /Towards Haskell in the Cloud/ (Epstein et al, Haskell
                      Symposium 2011) introduces the concept of /static/ values:
                      values that are known at compile time. In a distributed


### PR DESCRIPTION
We can add support for static pointers in a fully backwards compatible way; we do not even need to bump the major version number on the package. All we are doing is adding an additional constructor to `StaticLabel`. Once all the work on `polystatic` (however it gets resolved eventually) and the new structure of the SPT is implemented in GHC, we probably want to modify this implementation, but until that time we can make use of the new static pointers extension _right now_. Being able to avoid `remotable` and co makes life a lot easier. I've tested this in a Cloud Haskell application we're developing and it seems to work very well. It's certainly cleaned out code up nicely.

Note that even if we change the internal implementation, the user facing API that this PR provides is the right one:

``` haskell
staticPtr :: forall a. Typeable a => StaticPtr a -> Static a
```

This will not need to change even when the underlying mechanisms change.