### PR TITLE
Role of static should be nominal

### DIFF
--- a/src/Control/Distributed/Static.hs
+++ b/src/Control/Distributed/Static.hs
@@ -170,6 +170,7 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 710
 {-# LANGUAGE StaticPointers #-}
+{-# LANGUAGE RoleAnnotations #-}
 #endif
 module Control.Distributed.Static
   ( -- * Static values
@@ -288,6 +289,11 @@ instance NFData StaticLabel where
 -- | A static value. Static is opaque; see 'staticLabel' and 'staticApply'.
 newtype Static a = Static StaticLabel
   deriving (Eq, Ord, Typeable, Show)
+
+-- Trying to 'coerce' static values will lead to unification errors
+#if __GLASGOW_HASKELL__ >= 710
+type role Static nominal
+#endif
 
 instance NFData (Static a) where
   rnf (Static s) = rnf s
@@ -493,7 +499,7 @@ decodeEnvPairStatic :: Static (ByteString -> (ByteString, ByteString))
 decodeEnvPairStatic = staticLabel "$decodeEnvPair"
 
 -- | Closure application
-closureApply :: forall a b . 
+closureApply :: forall a b .
                 Closure (a -> b) -> Closure a -> Closure b
 closureApply (Closure fdec fenv) (Closure xdec xenv) =
     closure decoder (encode (fenv, xenv))


### PR DESCRIPTION
To see why, consider

``` haskell
    ``` haskell
    {-# OPTIONS_GHC -Wall #-}
    module Main (main) where
    
    import Control.Distributed.Static
    import Data.Rank1Dynamic
    import Data.Rank1Typeable
    import GHC.Prim (coerce)
    import GHC.Types (Coercible)
    import Unsafe.Coerce (unsafeCoerce)
    
    newtype T = T Bool
      deriving (Show)
    
    remoteTable :: RemoteTable
    remoteTable = registerStatic "$true" (toDynamic True)
                . registerStatic "$unsafeCoerce" (toDynamic (unsafeCoerce :: ANY1 -> ANY2))
                $ initRemoteTable
    staticUnsafeCoerce :: Static (a -> b)
    staticUnsafeCoerce = staticLabel "$unsafeCoerce"
    
    staticTrue :: Static Bool
    staticTrue = staticLabel "$true"
    
    staticCoerce :: Coercible a b => Static a -> Static b
    staticCoerce = staticApply staticUnsafeCoerce
    
    main :: IO ()
    main = do
        let a :: Either String Bool
            a = unstatic remoteTable staticTrue
        print a

        let b :: Either String T
            b = unstatic remoteTable (coerce staticTrue)
        print b
    
        let c :: Either String T
            c = unstatic remoteTable (staticCoerce staticTrue)
        print c
    
        putStrLn "done"
```

The definition of `b` will result in "Cannot unify Bool and T". For completeness, this example also shows how one might implement `staticCoerce` if one wished to do so; all this PR does is add a role annotation to static to rule out using `coerce`. 