### PR TITLE
Increase upper bound of binary

### DIFF
--- a/distributed-static.cabal
+++ b/distributed-static.cabal
@@ -36,7 +36,7 @@ Library
                        rank1dynamic >= 0.1 && < 0.4,
                        containers >= 0.4 && < 0.6,
                        bytestring >= 0.9 && < 0.11,
-                       binary >= 0.5 && < 0.8,
+                       binary >= 0.5 && < 0.9,
                        deepseq >= 1.3.0.1 && < 1.6
   HS-Source-Dirs:      src
   Default-Language:    Haskell2010


### PR DESCRIPTION
Since it compiles with binary-0.8.3.0, and it doesn't have any
 breaking change.