### PR TITLE
Allow bytestring-0.11 for ghc-9.2

### DIFF
--- a/distributed-static.cabal
+++ b/distributed-static.cabal
@@ -35,7 +35,7 @@ Library
   Build-Depends:       base >= 4.8 && < 5,
                        rank1dynamic >= 0.1 && < 0.5,
                        containers >= 0.4 && < 0.7,
-                       bytestring >= 0.10 && < 0.11,
+                       bytestring >= 0.10 && < 0.12,
                        binary >= 0.5 && < 0.9,
                        deepseq >= 1.3.0.1 && < 1.6
   HS-Source-Dirs:      src


### PR DESCRIPTION
This change enables building distributed-static with ghc-9.2.